### PR TITLE
chore: removed screenshot option for new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,7 +1,7 @@
 name: 📄 Documentation
 description: Found an issue in the documentation? You can use this one!
-title: '[DOCS] <description>'
-labels: ['documentation']
+title: "[DOCS] <description>"
+labels: ["documentation"]
 body:
   - type: textarea
     id: description
@@ -10,10 +10,3 @@ body:
       description: Description of the question or issue, also include what you tried and what didn't work
     validations:
       required: true
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: Screenshots if applicable
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/features.yml
+++ b/.github/ISSUE_TEMPLATE/features.yml
@@ -1,7 +1,7 @@
 name: 💡 General Feature Request
 description: Have a new idea/feature for this project? Please suggest!
-title: '[FEATURE] <description>'
-labels: ['feature']
+title: "[FEATURE] <description>"
+labels: ["feature"]
 body:
   - type: textarea
     id: description
@@ -10,10 +10,3 @@ body:
       description: Description of the enhancement you propose, also include what you tried and what worked.
     validations:
       required: true
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: Screenshots if applicable
-    validations:
-      required: false


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

### 🛠️ Fixes Issue
Closes #43 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

### 👨‍💻 Changes proposed
Removed the screenshot section from `docs` and `general feature ` issue templates. 
However haven't removed the screenshot section from `bug` issue template, because sometime it may happen that user needs to attach the screenshot of the bug

<!-- List all the proposed changes in your PR -->

### ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

### 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

### 📷 Screenshots
