### PR TITLE
fix: inter font rendering

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+	html {
+		font-feature-settings: 'cv03', 'cv04', 'cv11';
+	}
+}
+
 .input-field {
 	@apply rounded-md border border-black p-2;
 }


### PR DESCRIPTION

### 🛠️ Fixes Issue
Closes #127 

### 👨‍💻 Changes proposed
Apply `font-feature-settings` property to make Inter font look like it appears in Tailwind UI.k