### PR TITLE
feat: add Footer and cleanup homepage

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import { FaGithub, FaDiscord, FaTwitter } from 'react-icons/fa';
+
+export function Footer() {
+	return (
+		<footer className='grid justify-items-center border-t-2 p-6'>
+			<div className='flex flex-row space-x-6'>
+				<Link href='https://github.com/ykdojo/defaang'>
+					<a target='_blank' rel='noopener noreferrer'>
+						<FaGithub className='h-7 w-7' title='GitHub' />
+					</a>
+				</Link>
+				<Link href='https://discord.gg/VjrAf3N7Yn'>
+					<a target='_blank' rel='noopener noreferrer'>
+						<FaDiscord className='h-7 w-7' title='Discord' />
+					</a>
+				</Link>
+				<Link href='https://twitter.com/ykdojo'>
+					<a target='_blank' rel='noopener noreferrer'>
+						<FaTwitter className='h-7 w-7' title='Twitter' />
+					</a>
+				</Link>
+			</div>
+		</footer>
+	);
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,11 +15,6 @@ export function Footer() {
 						<FaDiscord className='h-7 w-7' title='Discord' />
 					</a>
 				</Link>
-				<Link href='https://twitter.com/ykdojo'>
-					<a target='_blank' rel='noopener noreferrer'>
-						<FaTwitter className='h-7 w-7' title='Twitter' />
-					</a>
-				</Link>
 			</div>
 		</footer>
 	);

--- a/src/components/PlaceHolder.tsx
+++ b/src/components/PlaceHolder.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+export function PlaceHolder() {
+	return (
+		<>
+			<h1 className='text-3xl font-bold text-gray-800 lg:text-5xl'>Welcome to defaang 🎉</h1>
+			<h3 className='mt-8 text-xl font-normal leading-7 text-gray-600 lg:text-3xl lg:leading-10'>
+				{'A website that will curate recently-asked interview questions from FAANG+ to help people practice & prep!'}
+			</h3>
+			<p className='text-md my-8 font-medium text-teal-600 lg:text-xl'>
+				This is a brand new website and it is something that is being created on the Go
+			</p>
+			<p className='lg:text-md text-sm font-medium text-gray-900'>
+				If you have any idea about something you want to see in the website, feel free to start an issue or discussion
+				around that on our
+				<Link href='https://discord.gg/VjrAf3N7Yn'>
+					<a target='_blank' rel='noopener noreferrer' className='text-blue-900'>
+						{' discord '}
+					</a>
+				</Link>
+				server or
+				<Link href='https://github.com/ykdojo/defaang/discussions'>
+					<a target='_blank' rel='noopener noreferrer' className='text-blue-900'>
+						{' github discussions'}
+					</a>
+				</Link>
+			</p>
+		</>
+	);
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,28 +2,22 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import { Header } from '../components/Header';
 import type { UserProps } from '../lib/types';
+import { PlaceHolder } from '../components/PlaceHolder';
+import { Footer } from '../components/Footer';
 
 const Home: NextPage<UserProps> = ({ user }) => {
 	return (
-		<div>
+		<>
 			<Head>
 				<title>{'defaang: recently-asked interview questions at FAANG+, collected & curated'}</title>
 			</Head>
+
 			<Header user={user} />
-			<main className='flex h-[calc(100vh-4rem)] w-full flex-col items-center justify-center px-[5%]  text-center lg:h-[calc(100vh-6rem)] lg:px-[20%]'>
-				<h1 className='text-3xl font-bold text-gray-800 lg:text-5xl'>Welcome to defaang 🎉</h1>
-				<h3 className='mt-8 text-xl font-normal leading-7 text-gray-600 lg:text-3xl lg:leading-10'>
-					A website that will curate recently-asked interview questions from FAANG+ to help people practice & prep!
-				</h3>
-				<p className='text-md my-8 font-medium text-teal-600 lg:text-xl'>
-					This is a brand new website and it something that is being created on the Go
-				</p>
-				<p className='lg:text-md text-sm font-medium text-gray-900'>
-					If you have any idea about something you want to see in the website, feel free to start an issue or discussion
-					around that on our discord server or github discussions.
-				</p>
+			<main className='flex min-h-screen flex-col items-center justify-center px-[5%] text-center lg:px-[20%]'>
+				<PlaceHolder />
 			</main>
-		</div>
+			<Footer />
+		</>
 	);
 };
 


### PR DESCRIPTION
- Added a new `Footer` component containing social links.
- Moved the placeholder text on homepage to a `PlaceHolder` component.
- Added links to Discord and GitHub discussions in the placeholder text.
- Removed unnecessary CSS on `main` on the homepage.