### PR TITLE
dx: add test job and pre-commit hook for type checking

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,3 +44,21 @@ jobs:
 
       - name: Run Prettier
         run: npm run format:check
+
+  TypeCheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Node v16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tsc
+        run: npm run type:check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx --no-install lint-staged
+npm run type:check


### PR DESCRIPTION
This will make sure there are no TypeScript-specific errors in the changes by checking them during the commit. The `TypeCheck` job will perform the same check but on the PR.