### PR TITLE
dx: update deps, validate env vars, and set jsonc formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
 	},
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,5 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
 	reactStrictMode: true,
-	experimental: {
-		images: {
-			allowFutureImage: true,
-		},
-	},
+	swcMinify: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@supabase/supabase-js": "^1.35.6",
 				"@tailwindcss/forms": "^0.5.3",
 				"clsx": "^1.2.1",
-				"next": "12.2.5",
+				"next": "^12.3.0",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
 				"react-hook-form": "^7.34.2",
@@ -136,8 +136,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@next/env": {
-			"version": "12.2.5",
-			"license": "MIT"
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.0.tgz",
+			"integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
 		},
 		"node_modules/@next/eslint-plugin-next": {
 			"version": "12.2.5",
@@ -167,9 +168,9 @@
 			}
 		},
 		"node_modules/@next/swc-android-arm-eabi": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.5.tgz",
-			"integrity": "sha512-cPWClKxGhgn2dLWnspW+7psl3MoLQUcNqJqOHk2BhNcou9ARDtC0IjQkKe5qcn9qg7I7U83Gp1yh2aesZfZJMA==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
+			"integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
 			"cpu": [
 				"arm"
 			],
@@ -182,9 +183,9 @@
 			}
 		},
 		"node_modules/@next/swc-android-arm64": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.5.tgz",
-			"integrity": "sha512-vMj0efliXmC5b7p+wfcQCX0AfU8IypjkzT64GiKJD9PgiA3IILNiGJr1fw2lyUDHkjeWx/5HMlMEpLnTsQslwg==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
+			"integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
 			"cpu": [
 				"arm64"
 			],
@@ -197,11 +198,12 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
+			"integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
 			"cpu": [
 				"arm64"
 			],
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -211,9 +213,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.5.tgz",
-			"integrity": "sha512-5o8bTCgAmtYOgauO/Xd27vW52G2/m3i5PX7MUYePquxXAnX73AAtqA3WgPXBRitEB60plSKZgOTkcpqrsh546A==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
+			"integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
 			"cpu": [
 				"x64"
 			],
@@ -226,9 +228,9 @@
 			}
 		},
 		"node_modules/@next/swc-freebsd-x64": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
-			"integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
+			"integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
 			"cpu": [
 				"x64"
 			],
@@ -241,9 +243,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm-gnueabihf": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.5.tgz",
-			"integrity": "sha512-2ZE2/G921Acks7UopJZVMgKLdm4vN4U0yuzvAMJ6KBavPzqESA2yHJlm85TV/K9gIjKhSk5BVtauIUntFRP8cg==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
+			"integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
 			"cpu": [
 				"arm"
 			],
@@ -256,9 +258,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.5.tgz",
-			"integrity": "sha512-/I6+PWVlz2wkTdWqhlSYYJ1pWWgUVva6SgX353oqTh8njNQp1SdFQuWDqk8LnM6ulheVfSsgkDzxrDaAQZnzjQ==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
+			"integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -271,9 +273,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.5.tgz",
-			"integrity": "sha512-LPQRelfX6asXyVr59p5sTpx5l+0yh2Vjp/R8Wi4X9pnqcayqT4CUJLiHqCvZuLin3IsFdisJL0rKHMoaZLRfmg==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
+			"integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -286,9 +288,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.5.tgz",
-			"integrity": "sha512-0szyAo8jMCClkjNK0hknjhmAngUppoRekW6OAezbEYwHXN/VNtsXbfzgYOqjKWxEx3OoAzrT3jLwAF0HdX2MEw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
+			"integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
 			"cpu": [
 				"x64"
 			],
@@ -301,9 +303,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.5.tgz",
-			"integrity": "sha512-zg/Y6oBar1yVnW6Il1I/08/2ukWtOG6s3acdJdEyIdsCzyQi4RLxbbhkD/EGQyhqBvd3QrC6ZXQEXighQUAZ0g==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
+			"integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
 			"cpu": [
 				"x64"
 			],
@@ -316,9 +318,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.5.tgz",
-			"integrity": "sha512-3/90DRNSqeeSRMMEhj4gHHQlLhhKg5SCCoYfE3kBjGpE63EfnblYUqsszGGZ9ekpKL/R4/SGB40iCQr8tR5Jiw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
+			"integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
 			"cpu": [
 				"arm64"
 			],
@@ -331,9 +333,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.5.tgz",
-			"integrity": "sha512-hGLc0ZRAwnaPL4ulwpp4D2RxmkHQLuI8CFOEEHdzZpS63/hMVzv81g8jzYA0UXbb9pus/iTc3VRbVbAM03SRrw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
+			"integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
 			"cpu": [
 				"ia32"
 			],
@@ -346,9 +348,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.5.tgz",
-			"integrity": "sha512-7h5/ahY7NeaO2xygqVrSG/Y8Vs4cdjxIjowTZ5W6CKoTKn7tmnuxlUc2h74x06FKmbhAd9agOjr/AOKyxYYm9Q==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
+			"integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
 			"cpu": [
 				"x64"
 			],
@@ -442,8 +444,9 @@
 			}
 		},
 		"node_modules/@swc/helpers": {
-			"version": "0.4.3",
-			"license": "MIT",
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+			"integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -2953,14 +2956,15 @@
 			"license": "MIT"
 		},
 		"node_modules/next": {
-			"version": "12.2.5",
-			"license": "MIT",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/next/-/next-12.3.0.tgz",
+			"integrity": "sha512-GpzI6me9V1+XYtfK0Ae9WD0mKqHyzQlGq1xH1rzNIYMASo4Tkl4rTe9jSqtBpXFhOS33KohXs9ZY38Akkhdciw==",
 			"dependencies": {
-				"@next/env": "12.2.5",
-				"@swc/helpers": "0.4.3",
+				"@next/env": "12.3.0",
+				"@swc/helpers": "0.4.11",
 				"caniuse-lite": "^1.0.30001332",
 				"postcss": "8.4.14",
-				"styled-jsx": "5.0.4",
+				"styled-jsx": "5.0.6",
 				"use-sync-external-store": "1.2.0"
 			},
 			"bin": {
@@ -2970,19 +2974,19 @@
 				"node": ">=12.22.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-android-arm-eabi": "12.2.5",
-				"@next/swc-android-arm64": "12.2.5",
-				"@next/swc-darwin-arm64": "12.2.5",
-				"@next/swc-darwin-x64": "12.2.5",
-				"@next/swc-freebsd-x64": "12.2.5",
-				"@next/swc-linux-arm-gnueabihf": "12.2.5",
-				"@next/swc-linux-arm64-gnu": "12.2.5",
-				"@next/swc-linux-arm64-musl": "12.2.5",
-				"@next/swc-linux-x64-gnu": "12.2.5",
-				"@next/swc-linux-x64-musl": "12.2.5",
-				"@next/swc-win32-arm64-msvc": "12.2.5",
-				"@next/swc-win32-ia32-msvc": "12.2.5",
-				"@next/swc-win32-x64-msvc": "12.2.5"
+				"@next/swc-android-arm-eabi": "12.3.0",
+				"@next/swc-android-arm64": "12.3.0",
+				"@next/swc-darwin-arm64": "12.3.0",
+				"@next/swc-darwin-x64": "12.3.0",
+				"@next/swc-freebsd-x64": "12.3.0",
+				"@next/swc-linux-arm-gnueabihf": "12.3.0",
+				"@next/swc-linux-arm64-gnu": "12.3.0",
+				"@next/swc-linux-arm64-musl": "12.3.0",
+				"@next/swc-linux-x64-gnu": "12.3.0",
+				"@next/swc-linux-x64-musl": "12.3.0",
+				"@next/swc-win32-arm64-msvc": "12.3.0",
+				"@next/swc-win32-ia32-msvc": "12.3.0",
+				"@next/swc-win32-x64-msvc": "12.3.0"
 			},
 			"peerDependencies": {
 				"fibers": ">= 3.1.0",
@@ -3988,8 +3992,9 @@
 			}
 		},
 		"node_modules/styled-jsx": {
-			"version": "5.0.4",
-			"license": "MIT",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.6.tgz",
+			"integrity": "sha512-xOeROtkK5MGMDimBQ3J6iPId8q0t/BDoG5XN6oKkZClVz9ISF/hihN8OCn2LggMU6N32aXnrXBdn3auSqNS9fA==",
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -4443,7 +4448,9 @@
 			"dev": true
 		},
 		"@next/env": {
-			"version": "12.2.5"
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.0.tgz",
+			"integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
 		},
 		"@next/eslint-plugin-next": {
 			"version": "12.2.5",
@@ -4467,79 +4474,81 @@
 			}
 		},
 		"@next/swc-android-arm-eabi": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.5.tgz",
-			"integrity": "sha512-cPWClKxGhgn2dLWnspW+7psl3MoLQUcNqJqOHk2BhNcou9ARDtC0IjQkKe5qcn9qg7I7U83Gp1yh2aesZfZJMA==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
+			"integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
 			"optional": true
 		},
 		"@next/swc-android-arm64": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.5.tgz",
-			"integrity": "sha512-vMj0efliXmC5b7p+wfcQCX0AfU8IypjkzT64GiKJD9PgiA3IILNiGJr1fw2lyUDHkjeWx/5HMlMEpLnTsQslwg==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
+			"integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
 			"optional": true
 		},
 		"@next/swc-darwin-arm64": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
+			"integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
 			"optional": true
 		},
 		"@next/swc-darwin-x64": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.5.tgz",
-			"integrity": "sha512-5o8bTCgAmtYOgauO/Xd27vW52G2/m3i5PX7MUYePquxXAnX73AAtqA3WgPXBRitEB60plSKZgOTkcpqrsh546A==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
+			"integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
 			"optional": true
 		},
 		"@next/swc-freebsd-x64": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.5.tgz",
-			"integrity": "sha512-yYUbyup1JnznMtEBRkK4LT56N0lfK5qNTzr6/DEyDw5TbFVwnuy2hhLBzwCBkScFVjpFdfiC6SQAX3FrAZzuuw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
+			"integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
 			"optional": true
 		},
 		"@next/swc-linux-arm-gnueabihf": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.5.tgz",
-			"integrity": "sha512-2ZE2/G921Acks7UopJZVMgKLdm4vN4U0yuzvAMJ6KBavPzqESA2yHJlm85TV/K9gIjKhSk5BVtauIUntFRP8cg==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
+			"integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
 			"optional": true
 		},
 		"@next/swc-linux-arm64-gnu": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.5.tgz",
-			"integrity": "sha512-/I6+PWVlz2wkTdWqhlSYYJ1pWWgUVva6SgX353oqTh8njNQp1SdFQuWDqk8LnM6ulheVfSsgkDzxrDaAQZnzjQ==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
+			"integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
 			"optional": true
 		},
 		"@next/swc-linux-arm64-musl": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.5.tgz",
-			"integrity": "sha512-LPQRelfX6asXyVr59p5sTpx5l+0yh2Vjp/R8Wi4X9pnqcayqT4CUJLiHqCvZuLin3IsFdisJL0rKHMoaZLRfmg==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
+			"integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
 			"optional": true
 		},
 		"@next/swc-linux-x64-gnu": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.5.tgz",
-			"integrity": "sha512-0szyAo8jMCClkjNK0hknjhmAngUppoRekW6OAezbEYwHXN/VNtsXbfzgYOqjKWxEx3OoAzrT3jLwAF0HdX2MEw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
+			"integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
 			"optional": true
 		},
 		"@next/swc-linux-x64-musl": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.5.tgz",
-			"integrity": "sha512-zg/Y6oBar1yVnW6Il1I/08/2ukWtOG6s3acdJdEyIdsCzyQi4RLxbbhkD/EGQyhqBvd3QrC6ZXQEXighQUAZ0g==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
+			"integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
 			"optional": true
 		},
 		"@next/swc-win32-arm64-msvc": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.5.tgz",
-			"integrity": "sha512-3/90DRNSqeeSRMMEhj4gHHQlLhhKg5SCCoYfE3kBjGpE63EfnblYUqsszGGZ9ekpKL/R4/SGB40iCQr8tR5Jiw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
+			"integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
 			"optional": true
 		},
 		"@next/swc-win32-ia32-msvc": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.5.tgz",
-			"integrity": "sha512-hGLc0ZRAwnaPL4ulwpp4D2RxmkHQLuI8CFOEEHdzZpS63/hMVzv81g8jzYA0UXbb9pus/iTc3VRbVbAM03SRrw==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
+			"integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
 			"optional": true
 		},
 		"@next/swc-win32-x64-msvc": {
-			"version": "12.2.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.5.tgz",
-			"integrity": "sha512-7h5/ahY7NeaO2xygqVrSG/Y8Vs4cdjxIjowTZ5W6CKoTKn7tmnuxlUc2h74x06FKmbhAd9agOjr/AOKyxYYm9Q==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
+			"integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
 			"optional": true
 		},
 		"@nodelib/fs.scandir": {
@@ -4605,7 +4614,9 @@
 			}
 		},
 		"@swc/helpers": {
-			"version": "0.4.3",
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+			"integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
 			"requires": {
 				"tslib": "^2.4.0"
 			}
@@ -6138,26 +6149,28 @@
 			"dev": true
 		},
 		"next": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/next/-/next-12.3.0.tgz",
+			"integrity": "sha512-GpzI6me9V1+XYtfK0Ae9WD0mKqHyzQlGq1xH1rzNIYMASo4Tkl4rTe9jSqtBpXFhOS33KohXs9ZY38Akkhdciw==",
 			"requires": {
-				"@next/env": "12.2.5",
-				"@next/swc-android-arm-eabi": "12.2.5",
-				"@next/swc-android-arm64": "12.2.5",
-				"@next/swc-darwin-arm64": "12.2.5",
-				"@next/swc-darwin-x64": "12.2.5",
-				"@next/swc-freebsd-x64": "12.2.5",
-				"@next/swc-linux-arm-gnueabihf": "12.2.5",
-				"@next/swc-linux-arm64-gnu": "12.2.5",
-				"@next/swc-linux-arm64-musl": "12.2.5",
-				"@next/swc-linux-x64-gnu": "12.2.5",
-				"@next/swc-linux-x64-musl": "12.2.5",
-				"@next/swc-win32-arm64-msvc": "12.2.5",
-				"@next/swc-win32-ia32-msvc": "12.2.5",
-				"@next/swc-win32-x64-msvc": "12.2.5",
-				"@swc/helpers": "0.4.3",
+				"@next/env": "12.3.0",
+				"@next/swc-android-arm-eabi": "12.3.0",
+				"@next/swc-android-arm64": "12.3.0",
+				"@next/swc-darwin-arm64": "12.3.0",
+				"@next/swc-darwin-x64": "12.3.0",
+				"@next/swc-freebsd-x64": "12.3.0",
+				"@next/swc-linux-arm-gnueabihf": "12.3.0",
+				"@next/swc-linux-arm64-gnu": "12.3.0",
+				"@next/swc-linux-arm64-musl": "12.3.0",
+				"@next/swc-linux-x64-gnu": "12.3.0",
+				"@next/swc-linux-x64-musl": "12.3.0",
+				"@next/swc-win32-arm64-msvc": "12.3.0",
+				"@next/swc-win32-ia32-msvc": "12.3.0",
+				"@next/swc-win32-x64-msvc": "12.3.0",
+				"@swc/helpers": "0.4.11",
 				"caniuse-lite": "^1.0.30001332",
 				"postcss": "8.4.14",
-				"styled-jsx": "5.0.4",
+				"styled-jsx": "5.0.6",
 				"use-sync-external-store": "1.2.0"
 			},
 			"dependencies": {
@@ -6679,7 +6692,9 @@
 			"dev": true
 		},
 		"styled-jsx": {
-			"version": "5.0.4",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.6.tgz",
+			"integrity": "sha512-xOeROtkK5MGMDimBQ3J6iPId8q0t/BDoG5XN6oKkZClVz9ISF/hihN8OCn2LggMU6N32aXnrXBdn3auSqNS9fA==",
 			"requires": {}
 		},
 		"supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,19 +15,19 @@
 				"next": "^12.3.0",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
-				"react-hook-form": "^7.34.2",
+				"react-hook-form": "^7.35.0",
 				"react-icons": "^4.4.0"
 			},
 			"devDependencies": {
 				"@types/node": "18.7.16",
-				"@types/react": "18.0.18",
+				"@types/react": "18.0.19",
 				"@types/react-dom": "18.0.6",
 				"@typescript-eslint/eslint-plugin": "^5.36.2",
 				"@typescript-eslint/parser": "^5.36.2",
 				"autoprefixer": "^10.4.8",
 				"cross-env": "^7.0.3",
 				"eslint": "8.23.0",
-				"eslint-config-next": "12.2.5",
+				"eslint-config-next": "12.3.0",
 				"eslint-config-prettier": "^8.5.0",
 				"husky": "^8.0.1",
 				"lint-staged": "^13.0.3",
@@ -35,7 +35,7 @@
 				"prettier": "^2.7.1",
 				"prettier-plugin-tailwindcss": "^0.1.13",
 				"tailwindcss": "^3.1.8",
-				"typescript": "4.8.2"
+				"typescript": "4.8.3"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -141,17 +141,19 @@
 			"integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
 		},
 		"node_modules/@next/eslint-plugin-next": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.0.tgz",
+			"integrity": "sha512-jVdq1qYTNDjUtulnE8/hkPv0pHILV4jMg5La99iaY/FFm20WxVnsAZtbNnMvlPbf8dc010oO304SX9yXbg5PAw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"glob": "7.1.7"
 			}
 		},
 		"node_modules/@next/eslint-plugin-next/node_modules/glob": {
 			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -489,9 +491,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.0.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.18.tgz",
-			"integrity": "sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==",
+			"version": "18.0.19",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.19.tgz",
+			"integrity": "sha512-BDc3Q+4Q3zsn7k9xZrKfjWyJsSlEDMs38gD1qp2eDazLCdcPqAT+vq1ND+Z8AGel/UiwzNUk8ptpywgNQcJ1MQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -1624,11 +1626,12 @@
 			}
 		},
 		"node_modules/eslint-config-next": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.0.tgz",
+			"integrity": "sha512-guHSkNyKnTBB8HU35COgAMeMV0E026BiYRYvyEVVaTOeFcnU3i1EI8/Da0Rl7H3Sgua5FEvoA0vYd2s8kdIUXg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@next/eslint-plugin-next": "12.2.5",
+				"@next/eslint-plugin-next": "12.3.0",
 				"@rushstack/eslint-patch": "^1.1.3",
 				"@typescript-eslint/parser": "^5.21.0",
 				"eslint-import-resolver-node": "^0.3.6",
@@ -3589,8 +3592,9 @@
 			}
 		},
 		"node_modules/react-hook-form": {
-			"version": "7.34.2",
-			"license": "MIT",
+			"version": "7.35.0",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.35.0.tgz",
+			"integrity": "sha512-9CYdOed+Itbiu5VMVxW0PK9mBR3f0gDGJcZEyUSm0eJbDymQ913TRs2gHcQZZmfTC+rtxyDFRuelMxx/+xwMcw==",
 			"engines": {
 				"node": ">=12.22.0"
 			},
@@ -4171,9 +4175,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -4453,7 +4457,9 @@
 			"integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
 		},
 		"@next/eslint-plugin-next": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.0.tgz",
+			"integrity": "sha512-jVdq1qYTNDjUtulnE8/hkPv0pHILV4jMg5La99iaY/FFm20WxVnsAZtbNnMvlPbf8dc010oO304SX9yXbg5PAw==",
 			"dev": true,
 			"requires": {
 				"glob": "7.1.7"
@@ -4461,6 +4467,8 @@
 			"dependencies": {
 				"glob": {
 					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -4653,9 +4661,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "18.0.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.18.tgz",
-			"integrity": "sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==",
+			"version": "18.0.19",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.19.tgz",
+			"integrity": "sha512-BDc3Q+4Q3zsn7k9xZrKfjWyJsSlEDMs38gD1qp2eDazLCdcPqAT+vq1ND+Z8AGel/UiwzNUk8ptpywgNQcJ1MQ==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -5350,10 +5358,12 @@
 			}
 		},
 		"eslint-config-next": {
-			"version": "12.2.5",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.0.tgz",
+			"integrity": "sha512-guHSkNyKnTBB8HU35COgAMeMV0E026BiYRYvyEVVaTOeFcnU3i1EI8/Da0Rl7H3Sgua5FEvoA0vYd2s8kdIUXg==",
 			"dev": true,
 			"requires": {
-				"@next/eslint-plugin-next": "12.2.5",
+				"@next/eslint-plugin-next": "12.3.0",
 				"@rushstack/eslint-patch": "^1.1.3",
 				"@typescript-eslint/parser": "^5.21.0",
 				"eslint-import-resolver-node": "^0.3.6",
@@ -6462,7 +6472,9 @@
 			}
 		},
 		"react-hook-form": {
-			"version": "7.34.2",
+			"version": "7.35.0",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.35.0.tgz",
+			"integrity": "sha512-9CYdOed+Itbiu5VMVxW0PK9mBR3f0gDGJcZEyUSm0eJbDymQ913TRs2gHcQZZmfTC+rtxyDFRuelMxx/+xwMcw==",
 			"requires": {}
 		},
 		"react-icons": {
@@ -6806,9 +6818,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
 			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
-				"@headlessui/react": "^1.6.6",
+				"@headlessui/react": "^1.7.0",
 				"@supabase/supabase-js": "^1.35.6",
-				"@tailwindcss/forms": "^0.5.2",
+				"@tailwindcss/forms": "^0.5.3",
 				"clsx": "^1.2.1",
 				"next": "12.2.5",
 				"react": "18.2.0",
@@ -19,14 +19,14 @@
 				"react-icons": "^4.4.0"
 			},
 			"devDependencies": {
-				"@types/node": "18.7.2",
-				"@types/react": "18.0.17",
+				"@types/node": "18.7.16",
+				"@types/react": "18.0.18",
 				"@types/react-dom": "18.0.6",
-				"@typescript-eslint/eslint-plugin": "^5.36.1",
-				"@typescript-eslint/parser": "^5.36.1",
+				"@typescript-eslint/eslint-plugin": "^5.36.2",
+				"@typescript-eslint/parser": "^5.36.2",
 				"autoprefixer": "^10.4.8",
 				"cross-env": "^7.0.3",
-				"eslint": "8.21.0",
+				"eslint": "8.23.0",
 				"eslint-config-next": "12.2.5",
 				"eslint-config-prettier": "^8.5.0",
 				"husky": "^8.0.1",
@@ -35,7 +35,7 @@
 				"prettier": "^2.7.1",
 				"prettier-plugin-tailwindcss": "^0.1.13",
 				"tailwindcss": "^3.1.8",
-				"typescript": "4.7.4"
+				"typescript": "4.8.2"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -84,8 +84,9 @@
 			}
 		},
 		"node_modules/@headlessui/react": {
-			"version": "1.6.6",
-			"license": "MIT",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-/nDsijOXRwXVLpUBEiYuWguIBSIN3ZbKyah+KPUiD8bdIKtX1U/k+qLYUEr7NCQnSF2e4w1dr8me42ECuG3cvw==",
 			"engines": {
 				"node": ">=10"
 			},
@@ -111,6 +112,19 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "Apache-2.0",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
@@ -435,8 +449,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/forms": {
-			"version": "0.5.2",
-			"license": "MIT",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
+			"integrity": "sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==",
 			"dependencies": {
 				"mini-svg-data-uri": "^1.2.3"
 			},
@@ -446,8 +461,9 @@
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
-			"dev": true,
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true
 		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
@@ -455,9 +471,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.2",
-			"dev": true,
-			"license": "MIT"
+			"version": "18.7.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+			"integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
+			"dev": true
 		},
 		"node_modules/@types/phoenix": {
 			"version": "1.5.4",
@@ -469,9 +486,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.0.17",
+			"version": "18.0.18",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.18.tgz",
+			"integrity": "sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -486,29 +504,20 @@
 				"@types/react": "*"
 			}
 		},
-		"node_modules/@types/react-dom/node_modules/@types/react": {
-			"version": "18.0.18",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/prop-types": "*",
-				"@types/scheduler": "*",
-				"csstype": "^3.0.2"
-			}
-		},
 		"node_modules/@types/scheduler": {
 			"version": "0.16.2",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
+			"integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.36.1",
-				"@typescript-eslint/type-utils": "5.36.1",
-				"@typescript-eslint/utils": "5.36.1",
+				"@typescript-eslint/scope-manager": "5.36.2",
+				"@typescript-eslint/type-utils": "5.36.2",
+				"@typescript-eslint/utils": "5.36.2",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -548,14 +557,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.36.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.1.tgz",
-			"integrity": "sha512-/IsgNGOkBi7CuDfUbwt1eOqUXF9WGVBW9dwEe1pi+L32XrTsZIgmDFIi2RxjzsvB/8i+MIf5JIoTEH8LOZ368A==",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
+			"integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.36.1",
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/typescript-estree": "5.36.1",
+				"@typescript-eslint/scope-manager": "5.36.2",
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/typescript-estree": "5.36.2",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -575,12 +584,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
+			"integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/visitor-keys": "5.36.1"
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/visitor-keys": "5.36.2"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -591,12 +601,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
+			"integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.36.1",
-				"@typescript-eslint/utils": "5.36.1",
+				"@typescript-eslint/typescript-estree": "5.36.2",
+				"@typescript-eslint/utils": "5.36.2",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -617,9 +628,10 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
+			"integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -629,12 +641,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
+			"integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/visitor-keys": "5.36.1",
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/visitor-keys": "5.36.2",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -656,8 +669,9 @@
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -669,14 +683,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
+			"integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.36.1",
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/typescript-estree": "5.36.1",
+				"@typescript-eslint/scope-manager": "5.36.2",
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/typescript-estree": "5.36.2",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -693,8 +708,9 @@
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
 			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -705,18 +721,20 @@
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/estraverse": {
 			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
+			"integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.36.1",
+				"@typescript-eslint/types": "5.36.2",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -1547,13 +1565,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.21.0",
+			"version": "8.23.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
+			"integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.0",
+				"@eslint/eslintrc": "^1.3.1",
 				"@humanwhocodes/config-array": "^0.10.4",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -1563,7 +1583,7 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.3",
+				"espree": "^9.4.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -1588,8 +1608,7 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -4147,9 +4166,10 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4225,11 +4245,6 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"license": "MIT"
-		},
-		"node_modules/v8-compile-cache": {
-			"version": "2.3.0",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/webidl-conversions": {
@@ -4399,7 +4414,9 @@
 			}
 		},
 		"@headlessui/react": {
-			"version": "1.6.6",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-/nDsijOXRwXVLpUBEiYuWguIBSIN3ZbKyah+KPUiD8bdIKtX1U/k+qLYUEr7NCQnSF2e4w1dr8me42ECuG3cvw==",
 			"requires": {}
 		},
 		"@humanwhocodes/config-array": {
@@ -4413,6 +4430,12 @@
 		},
 		"@humanwhocodes/gitignore-to-minimatch": {
 			"version": "1.0.2",
+			"dev": true
+		},
+		"@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
@@ -4588,13 +4611,17 @@
 			}
 		},
 		"@tailwindcss/forms": {
-			"version": "0.5.2",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
+			"integrity": "sha512-y5mb86JUoiUgBjY/o6FJSFZSEttfb3Q5gllE4xoKjAAD+vBrnIhE4dViwUuow3va8mpH4s9jyUbUbrRGoRdc2Q==",
 			"requires": {
 				"mini-svg-data-uri": "^1.2.3"
 			}
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
 		"@types/json5": {
@@ -4602,7 +4629,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.7.2",
+			"version": "18.7.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+			"integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
 			"dev": true
 		},
 		"@types/phoenix": {
@@ -4613,7 +4642,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "18.0.17",
+			"version": "18.0.18",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.18.tgz",
+			"integrity": "sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -4626,17 +4657,6 @@
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
-			},
-			"dependencies": {
-				"@types/react": {
-					"version": "18.0.18",
-					"dev": true,
-					"requires": {
-						"@types/prop-types": "*",
-						"@types/scheduler": "*",
-						"csstype": "^3.0.2"
-					}
-				}
 			}
 		},
 		"@types/scheduler": {
@@ -4644,12 +4664,14 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
+			"integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.36.1",
-				"@typescript-eslint/type-utils": "5.36.1",
-				"@typescript-eslint/utils": "5.36.1",
+				"@typescript-eslint/scope-manager": "5.36.2",
+				"@typescript-eslint/type-utils": "5.36.2",
+				"@typescript-eslint/utils": "5.36.2",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -4668,45 +4690,53 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.36.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.1.tgz",
-			"integrity": "sha512-/IsgNGOkBi7CuDfUbwt1eOqUXF9WGVBW9dwEe1pi+L32XrTsZIgmDFIi2RxjzsvB/8i+MIf5JIoTEH8LOZ368A==",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
+			"integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.36.1",
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/typescript-estree": "5.36.1",
+				"@typescript-eslint/scope-manager": "5.36.2",
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/typescript-estree": "5.36.2",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
+			"integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/visitor-keys": "5.36.1"
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/visitor-keys": "5.36.2"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
+			"integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "5.36.1",
-				"@typescript-eslint/utils": "5.36.1",
+				"@typescript-eslint/typescript-estree": "5.36.2",
+				"@typescript-eslint/utils": "5.36.2",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
+			"integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
+			"integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/visitor-keys": "5.36.1",
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/visitor-keys": "5.36.2",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -4716,6 +4746,8 @@
 			"dependencies": {
 				"semver": {
 					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -4724,19 +4756,23 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
+			"integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.36.1",
-				"@typescript-eslint/types": "5.36.1",
-				"@typescript-eslint/typescript-estree": "5.36.1",
+				"@typescript-eslint/scope-manager": "5.36.2",
+				"@typescript-eslint/types": "5.36.2",
+				"@typescript-eslint/typescript-estree": "5.36.2",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
 			"dependencies": {
 				"eslint-scope": {
 					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
@@ -4745,15 +4781,19 @@
 				},
 				"estraverse": {
 					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+					"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 					"dev": true
 				}
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.36.1",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
+			"integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.36.1",
+				"@typescript-eslint/types": "5.36.2",
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
@@ -5236,12 +5276,15 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.21.0",
+			"version": "8.23.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
+			"integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.0",
+				"@eslint/eslintrc": "^1.3.1",
 				"@humanwhocodes/config-array": "^0.10.4",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -5251,7 +5294,7 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.3",
+				"espree": "^9.4.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -5276,8 +5319,7 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -6749,7 +6791,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.7.4",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -6789,10 +6833,6 @@
 		},
 		"util-deprecate": {
 			"version": "1.0.2"
-		},
-		"v8-compile-cache": {
-			"version": "2.3.0",
-			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "3.0.1"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
 		"prepare": "husky install"
 	},
 	"dependencies": {
-		"@headlessui/react": "^1.6.6",
+		"@headlessui/react": "^1.7.0",
 		"@supabase/supabase-js": "^1.35.6",
-		"@tailwindcss/forms": "^0.5.2",
+		"@tailwindcss/forms": "^0.5.3",
 		"clsx": "^1.2.1",
 		"next": "12.2.5",
 		"react": "18.2.0",
@@ -23,14 +23,14 @@
 		"react-icons": "^4.4.0"
 	},
 	"devDependencies": {
-		"@types/node": "18.7.2",
-		"@types/react": "18.0.17",
+		"@types/node": "18.7.16",
+		"@types/react": "18.0.18",
 		"@types/react-dom": "18.0.6",
-		"@typescript-eslint/eslint-plugin": "^5.36.1",
-		"@typescript-eslint/parser": "^5.36.1",
+		"@typescript-eslint/eslint-plugin": "^5.36.2",
+		"@typescript-eslint/parser": "^5.36.2",
 		"autoprefixer": "^10.4.8",
 		"cross-env": "^7.0.3",
-		"eslint": "8.21.0",
+		"eslint": "8.23.0",
 		"eslint-config-next": "12.2.5",
 		"eslint-config-prettier": "^8.5.0",
 		"husky": "^8.0.1",
@@ -39,7 +39,7 @@
 		"prettier": "^2.7.1",
 		"prettier-plugin-tailwindcss": "^0.1.13",
 		"tailwindcss": "^3.1.8",
-		"typescript": "4.7.4"
+		"typescript": "4.8.2"
 	},
 	"version": "0.1.1",
 	"license": "MIT"

--- a/package.json
+++ b/package.json
@@ -19,19 +19,19 @@
 		"next": "^12.3.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
-		"react-hook-form": "^7.34.2",
+		"react-hook-form": "^7.35.0",
 		"react-icons": "^4.4.0"
 	},
 	"devDependencies": {
 		"@types/node": "18.7.16",
-		"@types/react": "18.0.18",
+		"@types/react": "18.0.19",
 		"@types/react-dom": "18.0.6",
 		"@typescript-eslint/eslint-plugin": "^5.36.2",
 		"@typescript-eslint/parser": "^5.36.2",
 		"autoprefixer": "^10.4.8",
 		"cross-env": "^7.0.3",
 		"eslint": "8.23.0",
-		"eslint-config-next": "12.2.5",
+		"eslint-config-next": "12.3.0",
 		"eslint-config-prettier": "^8.5.0",
 		"husky": "^8.0.1",
 		"lint-staged": "^13.0.3",
@@ -39,7 +39,7 @@
 		"prettier": "^2.7.1",
 		"prettier-plugin-tailwindcss": "^0.1.13",
 		"tailwindcss": "^3.1.8",
-		"typescript": "4.8.2"
+		"typescript": "4.8.3"
 	},
 	"version": "0.1.1",
 	"license": "MIT"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@supabase/supabase-js": "^1.35.6",
 		"@tailwindcss/forms": "^0.5.3",
 		"clsx": "^1.2.1",
-		"next": "12.2.5",
+		"next": "^12.3.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-hook-form": "^7.34.2",

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ user }: HeaderProps) {
 						<div className='flex h-16 items-center justify-between'>
 							<div className='flex items-center'>
 								<div className='flex-shrink-0'>
-									<Image src='/logo.svg' alt='defaang logo' width='32' height='32' className='block h-8 w-auto' />
+									<Image src='/logo.svg' alt='defaang logo' width='32' height='32' className='block h-8 w-8' />
 								</div>
 								<div className='hidden sm:ml-6 sm:block'>
 									<div className='flex space-x-4'>

--- a/src/components/Header/UserMenu.tsx
+++ b/src/components/Header/UserMenu.tsx
@@ -24,7 +24,7 @@ const menuLinks: Array<MenuLink> = [
 export function UserMenu({ user, className = '' }: UserMenuProps) {
 	return (
 		<Menu as='div' className={className}>
-			<Menu.Button className='rounded-full bg-gray-800 p-2 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800'>
+			<Menu.Button className='rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800'>
 				<span className='sr-only'>Open user menu</span>
 				<HiUser className='h-6 w-6' aria-hidden='true' />
 			</Menu.Button>

--- a/src/lib/images.d.ts
+++ b/src/lib/images.d.ts
@@ -1,0 +1,1 @@
+declare module '*.webp';

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -5,6 +5,7 @@ import { SignInForm } from '../components/SignIn/Form';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import type { PageProps } from '../lib/types';
+import bg_img from '../../public/bg_img.webp';
 
 export default function SignIn({ user }: PageProps) {
 	const router = useRouter();
@@ -42,9 +43,9 @@ export default function SignIn({ user }: PageProps) {
 				<div className='relative hidden w-0 flex-1 lg:block'>
 					<Image
 						className='absolute inset-0 h-full w-full object-cover'
-						src='/bg_img.webp'
+						src={bg_img}
 						alt='signin page background'
-						fill={true}
+						placeholder='blur'
 					/>
 				</div>
 			</main>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -5,6 +5,7 @@ import { SignUpForm } from '../components/SignUp/Form';
 import type { PageProps } from '../lib/types';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import bg_img from '../../public/bg_img.webp';
 
 export default function SignUp({ user }: PageProps) {
 	const router = useRouter();
@@ -42,9 +43,9 @@ export default function SignUp({ user }: PageProps) {
 				<div className='relative hidden w-0 flex-1 lg:block'>
 					<Image
 						className='absolute inset-0 h-full w-full object-cover'
-						src='/bg_img.webp'
+						src={bg_img}
 						alt='signup page background'
-						fill={true}
+						placeholder='blur'
 					/>
 				</div>
 			</main>

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,6 +1,9 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl: string = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey: string = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+if (!supabaseUrl) throw new Error('Supabase URL not found.');
+if (!supabaseAnonKey) throw new Error('Supabase Anon key not found.');
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "./*"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "./*", "./src/lib/images.d.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Bump all deps to the latest stable
- We use `prettier` to format code but vscode was using the built-in formatter for `jsonc` during save.
- Validate Supabase URL and Anon key at runtime.