### PR TITLE
feat: redirect unauthenticated users to signup page

### DIFF
--- a/src/pages/questions/new.tsx
+++ b/src/pages/questions/new.tsx
@@ -8,7 +8,7 @@ export default function SubmitQuestion(pageProps: PageProps) {
 
 	// If the user is not logged in, redirect them to the signin page
 	if (typeof localStorage !== 'undefined' && !localStorage['supabase.auth.token']) {
-		router.push('/signin');
+		router.push('/signup');
 	}
 
 	return (


### PR DESCRIPTION
Closes #195 

### ➕ Changes Introduced

Changed redirect in `pages/questions/new` from `router.push('signin')` -> `router.push('signup')`

Users that aren't signed in get redirected to sign up for an account instead of signing in.

