### PR TITLE
fix: Add meta tags and preview image for SEO optimization

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -12,19 +12,36 @@ export default function Document() {
           rel='stylesheet'
           href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Lexend:wght@400;500&display=swap'
         />
-        <meta name='description' content='// TODO: website description' />
+        <meta
+          name='description'
+          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
+        />
         {/* Open Graph Meta Tags */}
         <meta property='og:title' content='defaang' />
-        <meta property='og:description' content='// TODO: website description' />
+        <meta
+          property='og:description'
+          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
+        />
         <meta property='og:type' content='website' />
-        <meta property='og:image' content='// TODO: logo.png' />
+        <meta property='og:url' content='https://defaang.io/' />
+        <meta
+          property='og:image'
+          content='https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png'
+        />
         {/* Theme Color Meta Tags */}
-        <meta name='theme-color' content='// TODO: color' />
+        <meta name='theme-color' content='#2d7af0' />
         {/* Twitter Meta Tags  */}
-        <meta name='twitter:title' content='defaang' />
-        <meta name='twitter:description' content='// TODO: website description' />
-        <meta name='twitter:image' content='// TODO: https://root-domain-name/logo.png' />
-        <meta name='twitter:card' content='summary' />
+        <meta property='twitter:title' content='defaang' />
+        <meta
+          property='twitter:description'
+          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
+        />
+        <meta property='twitter:card' content='summary_large_image' />
+        <meta property='twitter:url' content='https://defaang.io/' />
+        <meta
+          property='twitter:image'
+          content='https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png'
+        />
       </Head>
       <body className='flex h-full flex-col bg-gray-100'>
         <Main />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,36 +10,7 @@ export default function Home({ session }: PageProps) {
   return (
     <>
       <Head>
-        <title>Defaang</title>
-        <meta name='title' content='Defaang' />
-        <meta
-          name='description'
-          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
-        />
-
-        <meta property='og:type' content='website' />
-        <meta property='og:url' content='https://defaang.io/' />
-        <meta property='og:title' content='Defaang' />
-        <meta
-          property='og:description'
-          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
-        />
-        <meta
-          property='og:image'
-          content='https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png'
-        />
-
-        <meta property='twitter:card' content='summary_large_image' />
-        <meta property='twitter:url' content='https://defaang.io/' />
-        <meta property='twitter:title' content='Defaang' />
-        <meta
-          property='twitter:description'
-          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
-        />
-        <meta
-          property='twitter:image'
-          content='https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png'
-        />
+        <title>{'defaang: recently-asked interview questions at FAANG+, collected & curated'}</title>
       </Head>
 
       <div className="bg-[url('/hero-background.jpg')] bg-top">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,36 @@ export default function Home({ session }: PageProps) {
   return (
     <>
       <Head>
-        <title>{'defaang: recently-asked interview questions at FAANG+, collected & curated'}</title>
+        <title>Defaang</title>
+        <meta name='title' content='Defaang' />
+        <meta
+          name='description'
+          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
+        />
+
+        <meta property='og:type' content='website' />
+        <meta property='og:url' content='https://defaang.io/' />
+        <meta property='og:title' content='Defaang' />
+        <meta
+          property='og:description'
+          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
+        />
+        <meta
+          property='og:image'
+          content='https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png'
+        />
+
+        <meta property='twitter:card' content='summary_large_image' />
+        <meta property='twitter:url' content='https://defaang.io/' />
+        <meta property='twitter:title' content='Defaang' />
+        <meta
+          property='twitter:description'
+          content='A website that will curate recently-asked interview questions from FAANG+ to help people practice and prep!'
+        />
+        <meta
+          property='twitter:image'
+          content='https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png'
+        />
       </Head>
 
       <div className="bg-[url('/hero-background.jpg')] bg-top">


### PR DESCRIPTION
### ➕ Changes Introduced
Add meta tags for SEO optimization & add [this](https://user-images.githubusercontent.com/1811651/190090988-bd062b3d-635b-4ce1-ac15-81d3c9edcb91.png) img from Readme as  preview image for Twitter & Open Graph.

### 📷 Screenshots
**Before:**
In this Screenshot meta tags have default comments.
![before](https://user-images.githubusercontent.com/80192140/193527599-3ca698ac-9f7b-42f5-b701-0ac5d9836121.png)

**After:**
![after](https://user-images.githubusercontent.com/80192140/193527679-2b892269-6339-430d-bb51-2964e398e003.png)
