### PR TITLE
feat: Highlight email box in sign in and sign up forms and display message if email invalid

### DIFF
--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -23,10 +23,10 @@ export function CallToAction() {
           </p>
           <div className='mt-10 flex justify-center gap-x-6'>
             <Button href='https://discord.com/invite/nNtVfKddDD' target='_blank' color='white'>
-              <span className='text-blue-600'>Join us on Discord</span>
+              <span className='text-[#7289DA]'>Join us on Discord</span>
             </Button>
             <Button href='https://www.twitch.tv/ykdojo' target='_blank' color='white'>
-              <span className='text-purple-600'>Join us on Twitch</span>
+              <span className='text-[#9146FF]'>Join us on Twitch</span>
             </Button>
           </div>
         </div>

--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -23,10 +23,10 @@ export function CallToAction() {
           </p>
           <div className='mt-10 flex justify-center gap-x-6'>
             <Button href='https://discord.com/invite/nNtVfKddDD' target='_blank' color='white'>
-              <span className='text-[#7289DA]'>Join us on Discord</span>
+              <span className='text-blue-600'>Join us on Discord</span>
             </Button>
             <Button href='https://www.twitch.tv/ykdojo' target='_blank' color='white'>
-              <span className='text-[#9146FF]'>Join us on Twitch</span>
+              <span className='text-purple-600'>Join us on Twitch</span>
             </Button>
           </div>
         </div>

--- a/src/components/SignIn/Form.tsx
+++ b/src/components/SignIn/Form.tsx
@@ -35,10 +35,14 @@ export function SignInForm() {
           id='email'
           autoComplete='email'
           required
-          className='relative block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm'
+          className='peer relative block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 invalid:text-pink-600 focus:z-10 focus:border-indigo-500 focus:outline-none  focus:ring-indigo-500 focus:invalid:border-pink-500 focus:invalid:ring-pink-500 sm:text-sm'
           value={email}
           onChange={e => setEmail(e.target.value)}
         />
+        <span className='invisible mt-2 text-sm text-pink-600 peer-invalid:visible'>
+          {' '}
+          Please provide a valid email address.{' '}
+        </span>
       </div>
       <div className='flex w-full flex-col space-y-2 '>
         <label htmlFor='password' className='text-sm text-gray-600'>

--- a/src/components/SignUp/Form.tsx
+++ b/src/components/SignUp/Form.tsx
@@ -42,10 +42,14 @@ export function SignUpForm() {
           id='email'
           autoComplete='email'
           required
-          className='relative block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm'
+          className='peer relative block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 invalid:text-pink-600 focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 focus:invalid:border-pink-500 focus:invalid:ring-pink-500 sm:text-sm'
           value={email}
           onChange={e => setEmail(e.target.value)}
         />
+        <span className='invisible mt-2 text-sm text-pink-600 peer-invalid:visible'>
+          {' '}
+          Please provide a valid email address.{' '}
+        </span>
       </div>
       <div className='flex w-full flex-col space-y-2'>
         <label htmlFor='username' className='text-sm text-gray-600'>


### PR DESCRIPTION
### 🛠️ Fixes Issue

Closes #252 

### ➕ Changes Introduced

* The email box ring and text is highlighted in tailwind color pink-600. "Please provide a valid email address" is displayed under it.
* Minor change: Changed Text color of "Join us on discord, twitch" to match more to their respective logos.

### 📷 Screenshots

Attached in the issue #252 
